### PR TITLE
Fixed issue #14: avoid multiple pointer copies

### DIFF
--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -25,10 +25,26 @@
 
 namespace rang {
 
-namespace {
-	std::streambuf const *RANG_coutbuf = std::cout.rdbuf();
-	std::streambuf const *RANG_cerrbuf = std::cerr.rdbuf();
-	std::streambuf const *RANG_clogbuf = std::clog.rdbuf();
+inline std::streambuf const*& RANG_coutbuf() {
+	static std::streambuf const* pOutbuff = std::cout.rdbuf();
+	return pOutbuff;
+}
+
+inline std::streambuf const*& RANG_cerrbuf() {
+	static std::streambuf const* pErrbuff = std::cerr.rdbuf();
+	return pErrbuff;
+}
+
+inline std::streambuf const*& RANG_clogbuf() {
+	static std::streambuf const* pLogbuff = std::clog.rdbuf();
+	return pLogbuff;
+}
+
+void init()
+{
+	RANG_coutbuf();
+	RANG_cerrbuf();
+	RANG_clogbuf();
 }
 
 enum class style {
@@ -117,7 +133,7 @@ inline bool supportsColor()
 
 inline bool isTerminal(const std::streambuf *osbuf)
 {
-	if (osbuf == RANG_coutbuf) {
+	if (osbuf == RANG_coutbuf()) {
 #if defined(OS_LINUX) || defined(OS_MAC)
 		return isatty(fileno(stdout)) ? true : false;
 #elif defined(OS_WIN)
@@ -125,7 +141,7 @@ inline bool isTerminal(const std::streambuf *osbuf)
 #endif
 	}
 
-	if (osbuf == RANG_cerrbuf || osbuf == RANG_clogbuf) {
+	if (osbuf == RANG_cerrbuf() || osbuf == RANG_clogbuf()) {
 #if defined(OS_LINUX) || defined(OS_MAC)
 		return isatty(fileno(stderr)) ? true : false;
 #elif defined(OS_WIN)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -11,6 +11,8 @@ TEST_CASE("Rang printing to non-terminals", "[file]")
 
 	SECTION("output is to a file")
 	{
+		rang::init();
+
 		std::ofstream out("out.txt");
 		std::streambuf *coutbuf = std::cout.rdbuf();
 		std::cout.rdbuf(out.rdbuf());


### PR DESCRIPTION
Replaced global vars with inline functions, as proposed [here](http://stackoverflow.com/questions/39450809/avoiding-redefinition-of-variables-for-single-header).

User is now required to call `rang::init()` before changing stream buffers.

Modified `test.cpp` to comply with that last rule.