### PR TITLE
Add installation and only build tests when enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,12 @@ enable_testing()
 include_directories(include)
 set(CATCH_HEADER_PATH ${PROJECT_SOURCE_DIR}/test/catch.hpp)
 
-add_executable(vTest ${PROJECT_SOURCE_DIR}/test/visualTest.cpp)
-add_executable(runTest ${PROJECT_SOURCE_DIR}/test/test.cpp ${CATCH_HEADER_PATH})
-add_executable(allColors ${PROJECT_SOURCE_DIR}/test/colortest.cpp)
+if(BUILD_TESTING)
+    add_executable(vTest ${PROJECT_SOURCE_DIR}/test/visualTest.cpp)
+    add_executable(runTest ${PROJECT_SOURCE_DIR}/test/test.cpp ${CATCH_HEADER_PATH})
+    add_executable(allColors ${PROJECT_SOURCE_DIR}/test/colortest.cpp)
 
-add_test(RTEST ${CMAKE_BINARY_DIR}/bin/runTest)
+    add_test(RTEST ${CMAKE_BINARY_DIR}/bin/runTest)
+endif()
+
+install(FILES ${PROJECT_SOURCE_DIR}/include/rang.hpp DESTINATION include)


### PR DESCRIPTION
This add installation to the cmake so it can be installed with `cmake --build . --target install`. It also only enables the tests if `BUILD_TESTING` is true. Cmake sets the variable to true by default, but now the user can configure cmake to disable them with `cmake .. _DBUILD_TESTING=Off`.

Also, with these changes, the package can be installed with cget now, with `cget install agauniyal/rang` and tested and installed with `cget install --test agauniyal/rang`.