### PR TITLE
 Msys/Cygwin support

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,3 +1,7 @@
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define _WIN32_WINNT 0x0600
+#endif
+
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 


### PR DESCRIPTION
Hello! As we knows, windows users who use terminal programs are professionals at most. Most known (and usable) pseudo terminal program is mintty. It's included in Msys and Cygwin packages. So, I'm added check when Msys/Cygwin console is attached. I'm also added separate static variables inside functions for terminal and ansi colors checking.

Tested on MSYS2. Without control::forceColor.

![rang-msys2](https://user-images.githubusercontent.com/9908175/32617080-a1a20430-c5a6-11e7-8a2a-b9600ec03f6c.png)
