### PR TITLE
Remove <versionhelpers.h> dependency

### DIFF
--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -23,7 +23,6 @@
 
 #include <windows.h>
 #include <io.h>
-#include <VersionHelpers.h>
 
 // Only defined in windows 10 onwards, redefining in lower windows since it
 // doesn't gets used in lower versions
@@ -230,19 +229,15 @@ namespace rang_implementation {
         if (h == INVALID_HANDLE_VALUE) {
             return false;
         }
-        if (IsWindowsVersionOrGreater(10, 0, 0)) {
-            DWORD dwMode = 0;
-            if (!GetConsoleMode(h, &dwMode)) {
-                return false;
-            }
-            dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-            if (!SetConsoleMode(h, dwMode)) {
-                return false;
-            }
-            return true;
-        } else {
+        DWORD dwMode = 0;
+        if (!GetConsoleMode(h, &dwMode)) {
             return false;
         }
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        if (!SetConsoleMode(h, dwMode)) {
+            return false;
+        }
+        return true;
     }
 
     inline bool supportsAnsi(const std::streambuf *osbuf) noexcept


### PR DESCRIPTION
[Recommended](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) (Example of Enabling Virtual Terminal Processing section) way to enable virtual terminal processing is to call [SetConsoleMode](https://docs.microsoft.com/en-us/windows/console/setconsolemode) with ENABLE_VIRTUAL_TERMINAL_PROCESSING and check return code:

> SetConsoleMode returning with STATUS_INVALID_PARAMETER is the current mechanism to determine when running on a down-level system. 

So, it is not necessary to include  <versionhelpers.h> and use the IsWindowsVersionOrGreater function. BTW, the <versionhelpers.h> header is not included in Windows SDK below 8.1 (you have to have your own copy).
