### PR TITLE
Update README.md to show more accurate info

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Supported attributes with their compatiblity are listed below -
 | `rang::style::bold`      | yes   | yes   |
 | `rang::style::dim`       | yes   | no    |
 | `rang::style::italic`    | yes   | no    |
-| `rang::style::underline` | yes   | maybe |
-| `rang::style::blink`     | no    | maybe |
+| `rang::style::underline` | yes   | no    |
+| `rang::style::blink`     | no    | no    |
 | `rang::style::rblink`    | no    | no    |
 | `rang::style::reversed`  | yes   | yes   |
 | `rang::style::conceal`   | maybe | yes   |


### PR DESCRIPTION
Made the table show correct "Underline" and "Blink" support status for "Old Win"

Tested using Legacy CMD on Windows 10 and CMD on Windows 7.

PS: Bold isn't exactly supported on Windows, it just changes the color to Full white.