### PR TITLE
Created a RangBuffer class in response to (enhancement) issue #52

### DIFF
--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -41,459 +41,567 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <bitset>
 
 namespace rang {
 
-/* For better compability with most of terminals do not use any style settings
- * except of reset, bold and reversed.
- * Note that on Windows terminals bold style is same as fgB color.
- */
-enum class style {
-    reset     = 0,
-    bold      = 1,
-    dim       = 2,
-    italic    = 3,
-    underline = 4,
-    blink     = 5,
-    rblink    = 6,
-    reversed  = 7,
-    conceal   = 8,
-    crossed   = 9
-};
+    /* For better compability with most of terminals do not use any style settings
+     * except of reset, bold and reversed.
+     * Note that on Windows terminals bold style is same as fgB color.
+     */
 
-enum class fg {
-    black   = 30,
-    red     = 31,
-    green   = 32,
-    yellow  = 33,
-    blue    = 34,
-    magenta = 35,
-    cyan    = 36,
-    gray    = 37,
-    reset   = 39
-};
-
-enum class bg {
-    black   = 40,
-    red     = 41,
-    green   = 42,
-    yellow  = 43,
-    blue    = 44,
-    magenta = 45,
-    cyan    = 46,
-    gray    = 47,
-    reset   = 49
-};
-
-enum class fgB {
-    black   = 90,
-    red     = 91,
-    green   = 92,
-    yellow  = 93,
-    blue    = 94,
-    magenta = 95,
-    cyan    = 96,
-    gray    = 97
-};
-
-enum class bgB {
-    black   = 100,
-    red     = 101,
-    green   = 102,
-    yellow  = 103,
-    blue    = 104,
-    magenta = 105,
-    cyan    = 106,
-    gray    = 107
-};
-
-enum class control {  // Behaviour of rang function calls
-    Off   = 0,  // toggle off rang style/color calls
-    Auto  = 1,  // (Default) autodect terminal and colorize if needed
-    Force = 2  // force ansi color output to non terminal streams
-};
-// Use rang::setControlMode to set rang control mode
-
-enum class winTerm {  // Windows Terminal Mode
-    Auto   = 0,  // (Default) automatically detects wheter Ansi or Native API
-    Ansi   = 1,  // Force use Ansi API
-    Native = 2  // Force use Native API
-};
-// Use rang::setWinTermMode to explicitly set terminal API for Windows
-// Calling rang::setWinTermMode have no effect on other OS
-
-namespace rang_implementation {
-
-    inline std::atomic<control> &controlMode() noexcept
+    enum class style
     {
-        static std::atomic<control> value(control::Auto);
-        return value;
-    }
+        reset     = 0,
+        bold      = 1,
+        dim       = 2,
+        italic    = 3,
+        underline = 4,
+        blink     = 5,
+        rblink    = 6,
+        reversed  = 7,
+        conceal   = 8,
+        crossed   = 9
+    };
 
-    inline std::atomic<winTerm> &winTermMode() noexcept
+    enum class fg
     {
-        static std::atomic<winTerm> termMode(winTerm::Auto);
-        return termMode;
-    }
+        black   = 30,
+        red     = 31,
+        green   = 32,
+        yellow  = 33,
+        blue    = 34,
+        magenta = 35,
+        cyan    = 36,
+        gray    = 37,
+        reset   = 39
+    };
 
-    inline bool supportsColor() noexcept
+    enum class bg
     {
-#if defined(OS_LINUX) || defined(OS_MAC)
+        black   = 40,
+        red     = 41,
+        green   = 42,
+        yellow  = 43,
+        blue    = 44,
+        magenta = 45,
+        cyan    = 46,
+        gray    = 47,
+        reset   = 49
+    };
 
-        static const bool result = [] {
-            const char *Terms[]
-              = { "ansi",    "color",  "console", "cygwin", "gnome",
-                  "konsole", "kterm",  "linux",   "msys",   "putty",
-                  "rxvt",    "screen", "vt100",   "xterm" };
+    enum class fgB
+    {
+        black   = 90,
+        red     = 91,
+        green   = 92,
+        yellow  = 93,
+        blue    = 94,
+        magenta = 95,
+        cyan    = 96,
+        gray    = 97,
+    };
 
-            const char *env_p = std::getenv("TERM");
-            if (env_p == nullptr) {
+    enum class bgB
+    {
+        black   = 100,
+        red     = 101,
+        green   = 102,
+        yellow  = 103,
+        blue    = 104,
+        magenta = 105,
+        cyan    = 106,
+        gray    = 107,
+    };
+
+    enum class control {  // Behaviour of rang function calls
+        Off   = 0,  // toggle off rang style/color calls
+        Auto  = 1,  // (Default) autodect terminal and colorize if needed
+        Force = 2  // force ansi color output to non terminal streams
+    };
+    // Use rang::setControlMode to set rang control mode
+
+    enum class winTerm {  // Windows Terminal Mode
+        Auto   = 0,  // (Default) automatically detects wheter Ansi or Native API
+        Ansi   = 1,  // Force use Ansi API
+        Native = 2  // Force use Native API
+    };
+    // Use rang::setWinTermMode to explicitly set terminal API for Windows
+    // Calling rang::setWinTermMode have no effect on other OS
+
+    namespace rang_implementation {
+
+        inline std::atomic<control> &controlMode() noexcept
+        {
+            static std::atomic<control> value(control::Auto);
+            return value;
+        }
+
+        inline std::atomic<winTerm> &winTermMode() noexcept
+        {
+            static std::atomic<winTerm> termMode(winTerm::Auto);
+            return termMode;
+        }
+
+        inline bool supportsColor() noexcept
+        {
+    #if defined(OS_LINUX) || defined(OS_MAC)
+
+            static const bool result = []
+            {
+                const char *Terms[] =
+                {
+                    "ansi",    "color",  "console", "cygwin", "gnome",
+                    "konsole", "kterm",  "linux",   "msys",   "putty",
+                    "rxvt",    "screen", "vt100",   "xterm"
+                };
+
+                const char *env_p = std::getenv("TERM");
+                if (env_p == nullptr) {
+                    return false;
+                }
+                return std::any_of(std::begin(Terms), std::end(Terms),
+                                   [&](const char *term) {
+                                       return std::strstr(env_p, term) != nullptr;
+                                   });
+            }();
+
+    #elif defined(OS_WIN)
+            // All windows versions support colors through native console methods
+            static constexpr bool result = true;
+    #endif
+            return result;
+        }
+
+    #ifdef OS_WIN
+
+
+        inline bool isMsysPty(int fd) noexcept
+        {
+            // Dynamic load for binary compability with old Windows
+            const auto ptrGetFileInformationByHandleEx
+              = reinterpret_cast<decltype(&GetFileInformationByHandleEx)>(
+                GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
+                               "GetFileInformationByHandleEx"));
+            if (!ptrGetFileInformationByHandleEx) {
                 return false;
             }
-            return std::any_of(std::begin(Terms), std::end(Terms),
-                               [&](const char *term) {
-                                   return std::strstr(env_p, term) != nullptr;
-                               });
-        }();
 
-#elif defined(OS_WIN)
-        // All windows versions support colors through native console methods
-        static constexpr bool result = true;
-#endif
-        return result;
-    }
+            HANDLE h = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+            if (h == INVALID_HANDLE_VALUE) {
+                return false;
+            }
 
-#ifdef OS_WIN
+            // Check that it's a pipe:
+            if (GetFileType(h) != FILE_TYPE_PIPE) {
+                return false;
+            }
 
+            // POD type is binary compatible with FILE_NAME_INFO from WinBase.h
+            // It have the same alignment and used to avoid UB in caller code
+            struct MY_FILE_NAME_INFO {
+                DWORD FileNameLength;
+                WCHAR FileName[MAX_PATH];
+            };
 
-    inline bool isMsysPty(int fd) noexcept
-    {
-        // Dynamic load for binary compability with old Windows
-        const auto ptrGetFileInformationByHandleEx
-          = reinterpret_cast<decltype(&GetFileInformationByHandleEx)>(
-            GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
-                           "GetFileInformationByHandleEx"));
-        if (!ptrGetFileInformationByHandleEx) {
+            auto pNameInfo = std::unique_ptr<MY_FILE_NAME_INFO>(
+              new (std::nothrow) MY_FILE_NAME_INFO());
+            if (!pNameInfo) {
+                return false;
+            }
+
+            // Check pipe name is template of
+            // {"cygwin-","msys-"}XXXXXXXXXXXXXXX-ptyX-XX
+            if (!ptrGetFileInformationByHandleEx(h, FileNameInfo, pNameInfo.get(),
+                                                 sizeof(MY_FILE_NAME_INFO))) {
+                return false;
+            }
+            std::wstring name(pNameInfo->FileName, pNameInfo->FileNameLength / sizeof(WCHAR));
+            if ((name.find(L"msys-") == std::wstring::npos
+                 && name.find(L"cygwin-") == std::wstring::npos)
+                || name.find(L"-pty") == std::wstring::npos) {
+                return false;
+            }
+
+            return true;
+        }
+
+    #endif
+
+        inline bool isTerminal(const std::streambuf *osbuf) noexcept
+        {
+            using std::cerr;
+            using std::clog;
+            using std::cout;
+    #if defined(OS_LINUX) || defined(OS_MAC)
+            if (osbuf == cout.rdbuf()) {
+                static const bool cout_term = isatty(fileno(stdout)) != 0;
+                return cout_term;
+            } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+                static const bool cerr_term = isatty(fileno(stderr)) != 0;
+                return cerr_term;
+            }
+    #elif defined(OS_WIN)
+            if (osbuf == cout.rdbuf()) {
+                static const bool cout_term
+                  = (_isatty(_fileno(stdout)) || isMsysPty(_fileno(stdout)));
+                return cout_term;
+            } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+                static const bool cerr_term
+                  = (_isatty(_fileno(stderr)) || isMsysPty(_fileno(stderr)));
+                return cerr_term;
+            }
+    #endif
             return false;
         }
 
-        HANDLE h = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
-        if (h == INVALID_HANDLE_VALUE) {
-            return false;
-        }
+        template <typename T>
+        using enableStd = typename std::enable_if<
+          std::is_same<T, rang::style>::value || std::is_same<T, rang::fg>::value
+            || std::is_same<T, rang::bg>::value || std::is_same<T, rang::fgB>::value
+            || std::is_same<T, rang::bgB>::value,
+          std::ostream &>::type;
 
-        // Check that it's a pipe:
-        if (GetFileType(h) != FILE_TYPE_PIPE) {
-            return false;
-        }
 
-        // POD type is binary compatible with FILE_NAME_INFO from WinBase.h
-        // It have the same alignment and used to avoid UB in caller code
-        struct MY_FILE_NAME_INFO {
-            DWORD FileNameLength;
-            WCHAR FileName[MAX_PATH];
+    #ifdef OS_WIN
+
+        struct SGR {  // Select Graphic Rendition parameters for Windows console
+            BYTE fgColor;  // foreground color (0-15) lower 3 rgb bits + intense bit
+            BYTE bgColor;  // background color (0-15) lower 3 rgb bits + intense bit
+            BYTE bold;  // emulated as FOREGROUND_INTENSITY bit
+            BYTE underline;  // emulated as BACKGROUND_INTENSITY bit
+            BOOLEAN inverse;  // swap foreground/bold & background/underline
+            BOOLEAN conceal;  // set foreground/bold to background/underline
         };
 
-        auto pNameInfo = std::unique_ptr<MY_FILE_NAME_INFO>(
-          new (std::nothrow) MY_FILE_NAME_INFO());
-        if (!pNameInfo) {
-            return false;
-        }
+        enum class AttrColor : BYTE {  // Color attributes for console screen buffer
+            black   = 0,
+            red     = 4,
+            green   = 2,
+            yellow  = 6,
+            blue    = 1,
+            magenta = 5,
+            cyan    = 3,
+            gray    = 7
+        };
 
-        // Check pipe name is template of
-        // {"cygwin-","msys-"}XXXXXXXXXXXXXXX-ptyX-XX
-        if (!ptrGetFileInformationByHandleEx(h, FileNameInfo, pNameInfo.get(),
-                                             sizeof(MY_FILE_NAME_INFO))) {
-            return false;
-        }
-        std::wstring name(pNameInfo->FileName, pNameInfo->FileNameLength / sizeof(WCHAR));
-        if ((name.find(L"msys-") == std::wstring::npos
-             && name.find(L"cygwin-") == std::wstring::npos)
-            || name.find(L"-pty") == std::wstring::npos) {
-            return false;
-        }
-
-        return true;
-    }
-
-#endif
-
-    inline bool isTerminal(const std::streambuf *osbuf) noexcept
-    {
-        using std::cerr;
-        using std::clog;
-        using std::cout;
-#if defined(OS_LINUX) || defined(OS_MAC)
-        if (osbuf == cout.rdbuf()) {
-            static const bool cout_term = isatty(fileno(stdout)) != 0;
-            return cout_term;
-        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
-            static const bool cerr_term = isatty(fileno(stderr)) != 0;
-            return cerr_term;
-        }
-#elif defined(OS_WIN)
-        if (osbuf == cout.rdbuf()) {
-            static const bool cout_term
-              = (_isatty(_fileno(stdout)) || isMsysPty(_fileno(stdout)));
-            return cout_term;
-        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
-            static const bool cerr_term
-              = (_isatty(_fileno(stderr)) || isMsysPty(_fileno(stderr)));
-            return cerr_term;
-        }
-#endif
-        return false;
-    }
-
-    template <typename T>
-    using enableStd = typename std::enable_if<
-      std::is_same<T, rang::style>::value || std::is_same<T, rang::fg>::value
-        || std::is_same<T, rang::bg>::value || std::is_same<T, rang::fgB>::value
-        || std::is_same<T, rang::bgB>::value,
-      std::ostream &>::type;
-
-
-#ifdef OS_WIN
-
-    struct SGR {  // Select Graphic Rendition parameters for Windows console
-        BYTE fgColor;  // foreground color (0-15) lower 3 rgb bits + intense bit
-        BYTE bgColor;  // background color (0-15) lower 3 rgb bits + intense bit
-        BYTE bold;  // emulated as FOREGROUND_INTENSITY bit
-        BYTE underline;  // emulated as BACKGROUND_INTENSITY bit
-        BOOLEAN inverse;  // swap foreground/bold & background/underline
-        BOOLEAN conceal;  // set foreground/bold to background/underline
-    };
-
-    enum class AttrColor : BYTE {  // Color attributes for console screen buffer
-        black   = 0,
-        red     = 4,
-        green   = 2,
-        yellow  = 6,
-        blue    = 1,
-        magenta = 5,
-        cyan    = 3,
-        gray    = 7
-    };
-
-    inline HANDLE getConsoleHandle(const std::streambuf *osbuf) noexcept
-    {
-        if (osbuf == std::cout.rdbuf()) {
-            static const HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
-            return hStdout;
-        } else if (osbuf == std::cerr.rdbuf() || osbuf == std::clog.rdbuf()) {
-            static const HANDLE hStderr = GetStdHandle(STD_ERROR_HANDLE);
-            return hStderr;
-        }
-        return INVALID_HANDLE_VALUE;
-    }
-
-    inline bool setWinTermAnsiColors(const std::streambuf *osbuf) noexcept
-    {
-        HANDLE h = getConsoleHandle(osbuf);
-        if (h == INVALID_HANDLE_VALUE) {
-            return false;
-        }
-        DWORD dwMode = 0;
-        if (!GetConsoleMode(h, &dwMode)) {
-            return false;
-        }
-        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-        if (!SetConsoleMode(h, dwMode)) {
-            return false;
-        }
-        return true;
-    }
-
-    inline bool supportsAnsi(const std::streambuf *osbuf) noexcept
-    {
-        using std::cerr;
-        using std::clog;
-        using std::cout;
-        if (osbuf == cout.rdbuf()) {
-            static const bool cout_ansi
-              = (isMsysPty(_fileno(stdout)) || setWinTermAnsiColors(osbuf));
-            return cout_ansi;
-        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
-            static const bool cerr_ansi
-              = (isMsysPty(_fileno(stderr)) || setWinTermAnsiColors(osbuf));
-            return cerr_ansi;
-        }
-        return false;
-    }
-
-    inline const SGR &defaultState() noexcept
-    {
-        static const SGR defaultSgr = []() -> SGR {
-            CONSOLE_SCREEN_BUFFER_INFO info;
-            WORD attrib = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
-            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE),
-                                           &info)
-                || GetConsoleScreenBufferInfo(GetStdHandle(STD_ERROR_HANDLE),
-                                              &info)) {
-                attrib = info.wAttributes;
+        inline HANDLE getConsoleHandle(const std::streambuf *osbuf) noexcept
+        {
+            if (osbuf == std::cout.rdbuf()) {
+                static const HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+                return hStdout;
+            } else if (osbuf == std::cerr.rdbuf() || osbuf == std::clog.rdbuf()) {
+                static const HANDLE hStderr = GetStdHandle(STD_ERROR_HANDLE);
+                return hStderr;
             }
-            SGR sgr     = { 0, 0, 0, 0, FALSE, FALSE };
-            sgr.fgColor = attrib & 0x0F;
-            sgr.bgColor = (attrib & 0xF0) >> 4;
-            return sgr;
-        }();
-        return defaultSgr;
-    }
-
-    inline BYTE ansi2attr(BYTE rgb) noexcept
-    {
-        static const AttrColor rev[8]
-          = { AttrColor::black,  AttrColor::red,  AttrColor::green,
-              AttrColor::yellow, AttrColor::blue, AttrColor::magenta,
-              AttrColor::cyan,   AttrColor::gray };
-        return static_cast<BYTE>(rev[rgb]);
-    }
-
-    inline void setWinSGR(rang::bg col, SGR &state) noexcept
-    {
-        if (col != rang::bg::reset) {
-            state.bgColor = ansi2attr(static_cast<BYTE>(col) - 40);
-        } else {
-            state.bgColor = defaultState().bgColor;
+            return INVALID_HANDLE_VALUE;
         }
-    }
 
-    inline void setWinSGR(rang::fg col, SGR &state) noexcept
-    {
-        if (col != rang::fg::reset) {
-            state.fgColor = ansi2attr(static_cast<BYTE>(col) - 30);
-        } else {
-            state.fgColor = defaultState().fgColor;
+        inline bool setWinTermAnsiColors(const std::streambuf *osbuf) noexcept
+        {
+            HANDLE h = getConsoleHandle(osbuf);
+            if (h == INVALID_HANDLE_VALUE) {
+                return false;
+            }
+            DWORD dwMode = 0;
+            if (!GetConsoleMode(h, &dwMode)) {
+                return false;
+            }
+            dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            if (!SetConsoleMode(h, dwMode)) {
+                return false;
+            }
+            return true;
         }
-    }
 
-    inline void setWinSGR(rang::bgB col, SGR &state) noexcept
-    {
-        state.bgColor = (BACKGROUND_INTENSITY >> 4)
-          | ansi2attr(static_cast<BYTE>(col) - 100);
-    }
-
-    inline void setWinSGR(rang::fgB col, SGR &state) noexcept
-    {
-        state.fgColor
-          = FOREGROUND_INTENSITY | ansi2attr(static_cast<BYTE>(col) - 90);
-    }
-
-    inline void setWinSGR(rang::style style, SGR &state) noexcept
-    {
-        switch (style) {
-            case rang::style::reset: state = defaultState(); break;
-            case rang::style::bold: state.bold = FOREGROUND_INTENSITY; break;
-            case rang::style::underline:
-            case rang::style::blink:
-                state.underline = BACKGROUND_INTENSITY;
-                break;
-            case rang::style::reversed: state.inverse = TRUE; break;
-            case rang::style::conceal: state.conceal = TRUE; break;
-            default: break;
+        inline bool supportsAnsi(const std::streambuf *osbuf) noexcept
+        {
+            using std::cerr;
+            using std::clog;
+            using std::cout;
+            if (osbuf == cout.rdbuf()) {
+                static const bool cout_ansi
+                  = (isMsysPty(_fileno(stdout)) || setWinTermAnsiColors(osbuf));
+                return cout_ansi;
+            } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+                static const bool cerr_ansi
+                  = (isMsysPty(_fileno(stderr)) || setWinTermAnsiColors(osbuf));
+                return cerr_ansi;
+            }
+            return false;
         }
-    }
 
-    inline SGR &current_state() noexcept
-    {
-        static SGR state = defaultState();
-        return state;
-    }
+        inline const SGR &defaultState() noexcept
+        {
+            static const SGR defaultSgr = []() -> SGR {
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                WORD attrib = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+                if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE),
+                                               &info)
+                    || GetConsoleScreenBufferInfo(GetStdHandle(STD_ERROR_HANDLE),
+                                                  &info)) {
+                    attrib = info.wAttributes;
+                }
+                SGR sgr     = { 0, 0, 0, 0, FALSE, FALSE };
+                sgr.fgColor = attrib & 0x0F;
+                sgr.bgColor = (attrib & 0xF0) >> 4;
+                return sgr;
+            }();
+            return defaultSgr;
+        }
 
-    inline WORD SGR2Attr(const SGR &state) noexcept
-    {
-        WORD attrib = 0;
-        if (state.conceal) {
-            if (state.inverse) {
-                attrib = (state.fgColor << 4) | state.fgColor;
-                if (state.bold)
-                    attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+        inline BYTE ansi2attr(BYTE rgb) noexcept
+        {
+            static const AttrColor rev[8]
+              = { AttrColor::black,  AttrColor::red,  AttrColor::green,
+                  AttrColor::yellow, AttrColor::blue, AttrColor::magenta,
+                  AttrColor::cyan,   AttrColor::gray };
+            return static_cast<BYTE>(rev[rgb]);
+        }
+
+        inline void setWinSGR(rang::bg col, SGR &state) noexcept
+        {
+            if (col != rang::bg::reset) {
+                state.bgColor = ansi2attr(static_cast<BYTE>(col) - 40);
             } else {
-                attrib = (state.bgColor << 4) | state.bgColor;
-                if (state.underline)
-                    attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+                state.bgColor = defaultState().bgColor;
             }
-        } else if (state.inverse) {
-            attrib = (state.fgColor << 4) | state.bgColor;
-            if (state.bold) attrib |= BACKGROUND_INTENSITY;
-            if (state.underline) attrib |= FOREGROUND_INTENSITY;
-        } else {
-            attrib = state.fgColor | (state.bgColor << 4) | state.bold
-              | state.underline;
         }
-        return attrib;
-    }
 
-    template <typename T>
-    inline void setWinColorAnsi(std::ostream &os, T const value)
-    {
-        os << "\033[" << static_cast<int>(value) << "m";
-    }
-
-    template <typename T>
-    inline void setWinColorNative(std::ostream &os, T const value)
-    {
-        const HANDLE h = getConsoleHandle(os.rdbuf());
-        if (h != INVALID_HANDLE_VALUE) {
-            setWinSGR(value, current_state());
-            // Out all buffered text to console with previous settings:
-            os.flush();
-            SetConsoleTextAttribute(h, SGR2Attr(current_state()));
+        inline void setWinSGR(rang::fg col, SGR &state) noexcept
+        {
+            if (col != rang::fg::reset) {
+                state.fgColor = ansi2attr(static_cast<BYTE>(col) - 30);
+            } else {
+                state.fgColor = defaultState().fgColor;
+            }
         }
-    }
 
-    template <typename T>
-    inline enableStd<T> setColor(std::ostream &os, T const value)
-    {
-        if (winTermMode() == winTerm::Auto) {
-            if (supportsAnsi(os.rdbuf())) {
+        inline void setWinSGR(rang::bgB col, SGR &state) noexcept
+        {
+            state.bgColor = (BACKGROUND_INTENSITY >> 4)
+              | ansi2attr(static_cast<BYTE>(col) - 100);
+        }
+
+        inline void setWinSGR(rang::fgB col, SGR &state) noexcept
+        {
+            state.fgColor
+              = FOREGROUND_INTENSITY | ansi2attr(static_cast<BYTE>(col) - 90);
+        }
+
+        inline void setWinSGR(rang::style style, SGR &state) noexcept
+        {
+            switch (style) {
+                case rang::style::reset: state = defaultState(); break;
+                case rang::style::bold: state.bold = FOREGROUND_INTENSITY; break;
+                case rang::style::underline:
+                case rang::style::blink:
+                    state.underline = BACKGROUND_INTENSITY;
+                    break;
+                case rang::style::reversed: state.inverse = TRUE; break;
+                case rang::style::conceal: state.conceal = TRUE; break;
+                default: break;
+            }
+        }
+
+        inline SGR &current_state() noexcept
+        {
+            static SGR state = defaultState();
+            return state;
+        }
+
+        inline WORD SGR2Attr(const SGR &state) noexcept
+        {
+            WORD attrib = 0;
+            if (state.conceal) {
+                if (state.inverse) {
+                    attrib = (state.fgColor << 4) | state.fgColor;
+                    if (state.bold)
+                        attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+                } else {
+                    attrib = (state.bgColor << 4) | state.bgColor;
+                    if (state.underline)
+                        attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+                }
+            } else if (state.inverse) {
+                attrib = (state.fgColor << 4) | state.bgColor;
+                if (state.bold) attrib |= BACKGROUND_INTENSITY;
+                if (state.underline) attrib |= FOREGROUND_INTENSITY;
+            } else {
+                attrib = state.fgColor | (state.bgColor << 4) | state.bold
+                  | state.underline;
+            }
+            return attrib;
+        }
+
+        template <typename T>
+        inline void setWinColorAnsi(std::ostream &os, T const value)
+        {
+            os << "\033[" << static_cast<int>(value) << "m";
+        }
+
+        template <typename T>
+        inline void setWinColorNative(std::ostream &os, T const value)
+        {
+            const HANDLE h = getConsoleHandle(os.rdbuf());
+            if (h != INVALID_HANDLE_VALUE) {
+                setWinSGR(value, current_state());
+                // Out all buffered text to console with previous settings:
+                os.flush();
+                SetConsoleTextAttribute(h, SGR2Attr(current_state()));
+            }
+        }
+
+        template <typename T>
+        inline enableStd<T> setColor(std::ostream &os, T const value)
+        {
+            if (winTermMode() == winTerm::Auto) {
+                if (supportsAnsi(os.rdbuf())) {
+                    setWinColorAnsi(os, value);
+                } else {
+                    setWinColorNative(os, value);
+                }
+            } else if (winTermMode() == winTerm::Ansi) {
                 setWinColorAnsi(os, value);
             } else {
                 setWinColorNative(os, value);
             }
-        } else if (winTermMode() == winTerm::Ansi) {
-            setWinColorAnsi(os, value);
-        } else {
-            setWinColorNative(os, value);
+            return os;
         }
-        return os;
-    }
-#else
+    #else
+        template <typename T>
+        inline enableStd<T> setColor(std::ostream &os, T const value)
+        {
+            return os << "\033[" << static_cast<int>(value) << "m";
+        }
+    #endif
+    }  // namespace rang_implementation
+
     template <typename T>
-    inline enableStd<T> setColor(std::ostream &os, T const value)
+    inline rang_implementation::enableStd<T> operator<<(std::ostream &os,
+                                                        const T value)
     {
-        return os << "\033[" << static_cast<int>(value) << "m";
+        const control option = rang_implementation::controlMode();
+        switch (option) {
+            case control::Auto:
+                return rang_implementation::supportsColor()
+                    && rang_implementation::isTerminal(os.rdbuf())
+                  ? rang_implementation::setColor(os, value)
+                  : os;
+            case control::Force: return rang_implementation::setColor(os, value);
+            default:    return os;
+        }
     }
-#endif
-}  // namespace rang_implementation
 
-template <typename T>
-inline rang_implementation::enableStd<T> operator<<(std::ostream &os,
-                                                    const T value)
-{
-    const control option = rang_implementation::controlMode();
-    switch (option) {
-        case control::Auto:
-            return rang_implementation::supportsColor()
-                && rang_implementation::isTerminal(os.rdbuf())
-              ? rang_implementation::setColor(os, value)
-              : os;
-        case control::Force: return rang_implementation::setColor(os, value);
-        default: return os;
+    inline void setWinTermMode(const rang::winTerm value) noexcept
+    {
+        rang_implementation::winTermMode() = value;
     }
-}
 
-inline void setWinTermMode(const rang::winTerm value) noexcept
-{
-    rang_implementation::winTermMode() = value;
-}
-
-inline void setControlMode(const control value) noexcept
-{
-    rang_implementation::controlMode() = value;
-}
+    inline void setControlMode(const control value) noexcept
+    {
+        rang_implementation::controlMode() = value;
+    }
 
 }  // namespace rang
+
+
+/**
+
+This is a buffer class to store all the settings the user wants to apply on the terminal.
+
+*/
+
+class RangBuffer
+{
+    private:
+
+    //The settings user can to apply
+    rang::style style;
+
+    rang::bg bgColor;
+    rang::bgB bgBColor;
+
+    rang::fg fgColor;
+    rang::fgB fgBColor;
+
+    //to check the user has applied which settings
+    std::bitset<5> elementSet;
+
+    public:
+
+    //initliaze elementSet. It contains 0 in each bit
+    RangBuffer() : elementSet()
+    {    }
+
+    /**ask the compiler to make the copy and move contructor and copy and move operator because
+        1) The compiler is much better
+        2) It will add a utility if the user wants to play around
+    */
+    RangBuffer(const RangBuffer& rg) = default;
+    RangBuffer(RangBuffer&& rg) = default;
+
+    RangBuffer& operator=(const RangBuffer& rg) = default;
+    RangBuffer& operator=(RangBuffer&& rg) = default;
+
+    void setStyle(const rang::style s)
+    {
+        style = s;
+        elementSet[0] = true;
+    }
+
+    void setBgColor(const rang::bg bg)
+    {
+        bgColor = bg;
+        elementSet[1] = true;
+    }
+
+    void setBgBColor(const rang::bgB bgB)
+    {
+        bgBColor = bgB;
+        elementSet[2] = true;
+    }
+
+    void setFgColor(rang::fg fg)
+    {
+        fgColor = fg;
+        elementSet[3] = true;
+    }
+
+    void setFgBColor(rang::fgB fgB)
+    {
+        fgBColor = fgB;
+        elementSet[4] = true;
+    }
+
+    void clear()
+    {
+        for(size_t i = 0;i < elementSet.size();++i)
+            elementSet[i] = false;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const RangBuffer& r)
+    {
+        if(r.elementSet.test(0))
+            os << r.style;
+
+        if(r.elementSet.test(1))
+            os << r.bgColor;
+
+        if(r.elementSet.test(2))
+            os << r.bgBColor;
+
+        if(r.elementSet.test(3))
+            os << r.fgColor;
+
+        if(r.elementSet.test(4))
+            os << r.fgBColor;
+
+        return os;
+    }
+
+    ~RangBuffer() = default;
+};
 
 #undef OS_LINUX
 #undef OS_WIN

--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -516,35 +516,35 @@ public:
     buffer& operator=(const buffer& b) = default;
     buffer& operator=(buffer&& b) = default;
 
-    void style(rang::style s)
+    void style(const rang::style s)
     {
         std::stringstream ss;
         ss << "\033[" << static_cast<int>(s) << "m";
         m_finalColor += ss.str();
     }
 
-    void bg(rang::bg b)
+    void bg(const rang::bg b)
     {
         std::stringstream ss;
         ss << "\033[" << static_cast<int>(b) << "m";
         m_finalColor += ss.str();
     }
 
-    void bgB(rang::bgB b)
+    void bgB(const rang::bgB b)
     {
         std::stringstream ss;
         ss << "\033[" << static_cast<int>(b) << "m";
         m_finalColor += ss.str();
     }
 
-    void fg(rang::fg f)
+    void fg(const rang::fg f)
     {
         std::stringstream ss;
         ss << "\033[" << static_cast<int>(f) << "m";
         m_finalColor += ss.str();
     }
 
-    void fgB(rang::fgB f)
+    void fgB(const rang::fgB f)
     {
         std::stringstream ss;
         ss << "\033[" << static_cast<int>(f) << "m";
@@ -609,4 +609,3 @@ public:
 #undef OS_MAC
 
 #endif /* ifndef RANG_DOT_HPP */
-

--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -41,553 +41,529 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
-#include <bitset>
+#include <string>
+#include <sstream>
 
 namespace rang {
 
-    /* For better compability with most of terminals do not use any style settings
-     * except of reset, bold and reversed.
-     * Note that on Windows terminals bold style is same as fgB color.
-     */
+/* For better compability with most of terminals do not use any style settings
+ * except of reset, bold and reversed.
+ * Note that on Windows terminals bold style is same as fgB color.
+ */
+enum class style {
+    reset     = 0,
+    bold      = 1,
+    dim       = 2,
+    italic    = 3,
+    underline = 4,
+    blink     = 5,
+    rblink    = 6,
+    reversed  = 7,
+    conceal   = 8,
+    crossed   = 9
+};
 
-    enum class style
+enum class fg {
+    black   = 30,
+    red     = 31,
+    green   = 32,
+    yellow  = 33,
+    blue    = 34,
+    magenta = 35,
+    cyan    = 36,
+    gray    = 37,
+    reset   = 39
+};
+
+enum class bg {
+    black   = 40,
+    red     = 41,
+    green   = 42,
+    yellow  = 43,
+    blue    = 44,
+    magenta = 45,
+    cyan    = 46,
+    gray    = 47,
+    reset   = 49
+};
+
+enum class fgB {
+    black   = 90,
+    red     = 91,
+    green   = 92,
+    yellow  = 93,
+    blue    = 94,
+    magenta = 95,
+    cyan    = 96,
+    gray    = 97
+};
+
+enum class bgB {
+    black   = 100,
+    red     = 101,
+    green   = 102,
+    yellow  = 103,
+    blue    = 104,
+    magenta = 105,
+    cyan    = 106,
+    gray    = 107
+};
+
+enum class control {  // Behaviour of rang function calls
+    Off   = 0,  // toggle off rang style/color calls
+    Auto  = 1,  // (Default) autodect terminal and colorize if needed
+    Force = 2  // force ansi color output to non terminal streams
+};
+// Use rang::setControlMode to set rang control mode
+
+enum class winTerm {  // Windows Terminal Mode
+    Auto   = 0,  // (Default) automatically detects wheter Ansi or Native API
+    Ansi   = 1,  // Force use Ansi API
+    Native = 2  // Force use Native API
+};
+// Use rang::setWinTermMode to explicitly set terminal API for Windows
+// Calling rang::setWinTermMode have no effect on other OS
+
+namespace rang_implementation {
+
+    inline std::atomic<control> &controlMode() noexcept
     {
-        reset     = 0,
-        bold      = 1,
-        dim       = 2,
-        italic    = 3,
-        underline = 4,
-        blink     = 5,
-        rblink    = 6,
-        reversed  = 7,
-        conceal   = 8,
-        crossed   = 9
-    };
+        static std::atomic<control> value(control::Auto);
+        return value;
+    }
 
-    enum class fg
+    inline std::atomic<winTerm> &winTermMode() noexcept
     {
-        black   = 30,
-        red     = 31,
-        green   = 32,
-        yellow  = 33,
-        blue    = 34,
-        magenta = 35,
-        cyan    = 36,
-        gray    = 37,
-        reset   = 39
-    };
+        static std::atomic<winTerm> termMode(winTerm::Auto);
+        return termMode;
+    }
 
-    enum class bg
+    inline bool supportsColor() noexcept
     {
-        black   = 40,
-        red     = 41,
-        green   = 42,
-        yellow  = 43,
-        blue    = 44,
-        magenta = 45,
-        cyan    = 46,
-        gray    = 47,
-        reset   = 49
-    };
+#if defined(OS_LINUX) || defined(OS_MAC)
 
-    enum class fgB
+        static const bool result = [] {
+            const char *Terms[]
+              = { "ansi",    "color",  "console", "cygwin", "gnome",
+                  "konsole", "kterm",  "linux",   "msys",   "putty",
+                  "rxvt",    "screen", "vt100",   "xterm" };
+
+            const char *env_p = std::getenv("TERM");
+            if (env_p == nullptr) {
+                return false;
+            }
+            return std::any_of(std::begin(Terms), std::end(Terms),
+                               [&](const char *term) {
+                                   return std::strstr(env_p, term) != nullptr;
+                               });
+        }();
+
+#elif defined(OS_WIN)
+        // All windows versions support colors through native console methods
+        static constexpr bool result = true;
+#endif
+        return result;
+    }
+
+#ifdef OS_WIN
+
+
+    inline bool isMsysPty(int fd) noexcept
     {
-        black   = 90,
-        red     = 91,
-        green   = 92,
-        yellow  = 93,
-        blue    = 94,
-        magenta = 95,
-        cyan    = 96,
-        gray    = 97,
-    };
-
-    enum class bgB
-    {
-        black   = 100,
-        red     = 101,
-        green   = 102,
-        yellow  = 103,
-        blue    = 104,
-        magenta = 105,
-        cyan    = 106,
-        gray    = 107,
-    };
-
-    enum class control {  // Behaviour of rang function calls
-        Off   = 0,  // toggle off rang style/color calls
-        Auto  = 1,  // (Default) autodect terminal and colorize if needed
-        Force = 2  // force ansi color output to non terminal streams
-    };
-    // Use rang::setControlMode to set rang control mode
-
-    enum class winTerm {  // Windows Terminal Mode
-        Auto   = 0,  // (Default) automatically detects wheter Ansi or Native API
-        Ansi   = 1,  // Force use Ansi API
-        Native = 2  // Force use Native API
-    };
-    // Use rang::setWinTermMode to explicitly set terminal API for Windows
-    // Calling rang::setWinTermMode have no effect on other OS
-
-    namespace rang_implementation {
-
-        inline std::atomic<control> &controlMode() noexcept
-        {
-            static std::atomic<control> value(control::Auto);
-            return value;
-        }
-
-        inline std::atomic<winTerm> &winTermMode() noexcept
-        {
-            static std::atomic<winTerm> termMode(winTerm::Auto);
-            return termMode;
-        }
-
-        inline bool supportsColor() noexcept
-        {
-    #if defined(OS_LINUX) || defined(OS_MAC)
-
-            static const bool result = []
-            {
-                const char *Terms[] =
-                {
-                    "ansi",    "color",  "console", "cygwin", "gnome",
-                    "konsole", "kterm",  "linux",   "msys",   "putty",
-                    "rxvt",    "screen", "vt100",   "xterm"
-                };
-
-                const char *env_p = std::getenv("TERM");
-                if (env_p == nullptr) {
-                    return false;
-                }
-                return std::any_of(std::begin(Terms), std::end(Terms),
-                                   [&](const char *term) {
-                                       return std::strstr(env_p, term) != nullptr;
-                                   });
-            }();
-
-    #elif defined(OS_WIN)
-            // All windows versions support colors through native console methods
-            static constexpr bool result = true;
-    #endif
-            return result;
-        }
-
-    #ifdef OS_WIN
-
-
-        inline bool isMsysPty(int fd) noexcept
-        {
-            // Dynamic load for binary compability with old Windows
-            const auto ptrGetFileInformationByHandleEx
-              = reinterpret_cast<decltype(&GetFileInformationByHandleEx)>(
-                GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
-                               "GetFileInformationByHandleEx"));
-            if (!ptrGetFileInformationByHandleEx) {
-                return false;
-            }
-
-            HANDLE h = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
-            if (h == INVALID_HANDLE_VALUE) {
-                return false;
-            }
-
-            // Check that it's a pipe:
-            if (GetFileType(h) != FILE_TYPE_PIPE) {
-                return false;
-            }
-
-            // POD type is binary compatible with FILE_NAME_INFO from WinBase.h
-            // It have the same alignment and used to avoid UB in caller code
-            struct MY_FILE_NAME_INFO {
-                DWORD FileNameLength;
-                WCHAR FileName[MAX_PATH];
-            };
-
-            auto pNameInfo = std::unique_ptr<MY_FILE_NAME_INFO>(
-              new (std::nothrow) MY_FILE_NAME_INFO());
-            if (!pNameInfo) {
-                return false;
-            }
-
-            // Check pipe name is template of
-            // {"cygwin-","msys-"}XXXXXXXXXXXXXXX-ptyX-XX
-            if (!ptrGetFileInformationByHandleEx(h, FileNameInfo, pNameInfo.get(),
-                                                 sizeof(MY_FILE_NAME_INFO))) {
-                return false;
-            }
-            std::wstring name(pNameInfo->FileName, pNameInfo->FileNameLength / sizeof(WCHAR));
-            if ((name.find(L"msys-") == std::wstring::npos
-                 && name.find(L"cygwin-") == std::wstring::npos)
-                || name.find(L"-pty") == std::wstring::npos) {
-                return false;
-            }
-
-            return true;
-        }
-
-    #endif
-
-        inline bool isTerminal(const std::streambuf *osbuf) noexcept
-        {
-            using std::cerr;
-            using std::clog;
-            using std::cout;
-    #if defined(OS_LINUX) || defined(OS_MAC)
-            if (osbuf == cout.rdbuf()) {
-                static const bool cout_term = isatty(fileno(stdout)) != 0;
-                return cout_term;
-            } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
-                static const bool cerr_term = isatty(fileno(stderr)) != 0;
-                return cerr_term;
-            }
-    #elif defined(OS_WIN)
-            if (osbuf == cout.rdbuf()) {
-                static const bool cout_term
-                  = (_isatty(_fileno(stdout)) || isMsysPty(_fileno(stdout)));
-                return cout_term;
-            } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
-                static const bool cerr_term
-                  = (_isatty(_fileno(stderr)) || isMsysPty(_fileno(stderr)));
-                return cerr_term;
-            }
-    #endif
+        // Dynamic load for binary compability with old Windows
+        const auto ptrGetFileInformationByHandleEx
+          = reinterpret_cast<decltype(&GetFileInformationByHandleEx)>(
+            GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
+                           "GetFileInformationByHandleEx"));
+        if (!ptrGetFileInformationByHandleEx) {
             return false;
         }
 
-        template <typename T>
-        using enableStd = typename std::enable_if<
-          std::is_same<T, rang::style>::value || std::is_same<T, rang::fg>::value
-            || std::is_same<T, rang::bg>::value || std::is_same<T, rang::fgB>::value
-            || std::is_same<T, rang::bgB>::value,
-          std::ostream &>::type;
-
-
-    #ifdef OS_WIN
-
-        struct SGR {  // Select Graphic Rendition parameters for Windows console
-            BYTE fgColor;  // foreground color (0-15) lower 3 rgb bits + intense bit
-            BYTE bgColor;  // background color (0-15) lower 3 rgb bits + intense bit
-            BYTE bold;  // emulated as FOREGROUND_INTENSITY bit
-            BYTE underline;  // emulated as BACKGROUND_INTENSITY bit
-            BOOLEAN inverse;  // swap foreground/bold & background/underline
-            BOOLEAN conceal;  // set foreground/bold to background/underline
-        };
-
-        enum class AttrColor : BYTE {  // Color attributes for console screen buffer
-            black   = 0,
-            red     = 4,
-            green   = 2,
-            yellow  = 6,
-            blue    = 1,
-            magenta = 5,
-            cyan    = 3,
-            gray    = 7
-        };
-
-        inline HANDLE getConsoleHandle(const std::streambuf *osbuf) noexcept
-        {
-            if (osbuf == std::cout.rdbuf()) {
-                static const HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
-                return hStdout;
-            } else if (osbuf == std::cerr.rdbuf() || osbuf == std::clog.rdbuf()) {
-                static const HANDLE hStderr = GetStdHandle(STD_ERROR_HANDLE);
-                return hStderr;
-            }
-            return INVALID_HANDLE_VALUE;
-        }
-
-        inline bool setWinTermAnsiColors(const std::streambuf *osbuf) noexcept
-        {
-            HANDLE h = getConsoleHandle(osbuf);
-            if (h == INVALID_HANDLE_VALUE) {
-                return false;
-            }
-            DWORD dwMode = 0;
-            if (!GetConsoleMode(h, &dwMode)) {
-                return false;
-            }
-            dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-            if (!SetConsoleMode(h, dwMode)) {
-                return false;
-            }
-            return true;
-        }
-
-        inline bool supportsAnsi(const std::streambuf *osbuf) noexcept
-        {
-            using std::cerr;
-            using std::clog;
-            using std::cout;
-            if (osbuf == cout.rdbuf()) {
-                static const bool cout_ansi
-                  = (isMsysPty(_fileno(stdout)) || setWinTermAnsiColors(osbuf));
-                return cout_ansi;
-            } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
-                static const bool cerr_ansi
-                  = (isMsysPty(_fileno(stderr)) || setWinTermAnsiColors(osbuf));
-                return cerr_ansi;
-            }
+        HANDLE h = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+        if (h == INVALID_HANDLE_VALUE) {
             return false;
         }
 
-        inline const SGR &defaultState() noexcept
-        {
-            static const SGR defaultSgr = []() -> SGR {
-                CONSOLE_SCREEN_BUFFER_INFO info;
-                WORD attrib = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
-                if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE),
-                                               &info)
-                    || GetConsoleScreenBufferInfo(GetStdHandle(STD_ERROR_HANDLE),
-                                                  &info)) {
-                    attrib = info.wAttributes;
-                }
-                SGR sgr     = { 0, 0, 0, 0, FALSE, FALSE };
-                sgr.fgColor = attrib & 0x0F;
-                sgr.bgColor = (attrib & 0xF0) >> 4;
-                return sgr;
-            }();
-            return defaultSgr;
+        // Check that it's a pipe:
+        if (GetFileType(h) != FILE_TYPE_PIPE) {
+            return false;
         }
 
-        inline BYTE ansi2attr(BYTE rgb) noexcept
-        {
-            static const AttrColor rev[8]
-              = { AttrColor::black,  AttrColor::red,  AttrColor::green,
-                  AttrColor::yellow, AttrColor::blue, AttrColor::magenta,
-                  AttrColor::cyan,   AttrColor::gray };
-            return static_cast<BYTE>(rev[rgb]);
+        // POD type is binary compatible with FILE_NAME_INFO from WinBase.h
+        // It have the same alignment and used to avoid UB in caller code
+        struct MY_FILE_NAME_INFO {
+            DWORD FileNameLength;
+            WCHAR FileName[MAX_PATH];
+        };
+
+        auto pNameInfo = std::unique_ptr<MY_FILE_NAME_INFO>(
+          new (std::nothrow) MY_FILE_NAME_INFO());
+        if (!pNameInfo) {
+            return false;
         }
 
-        inline void setWinSGR(rang::bg col, SGR &state) noexcept
-        {
-            if (col != rang::bg::reset) {
-                state.bgColor = ansi2attr(static_cast<BYTE>(col) - 40);
+        // Check pipe name is template of
+        // {"cygwin-","msys-"}XXXXXXXXXXXXXXX-ptyX-XX
+        if (!ptrGetFileInformationByHandleEx(h, FileNameInfo, pNameInfo.get(),
+                                             sizeof(MY_FILE_NAME_INFO))) {
+            return false;
+        }
+        std::wstring name(pNameInfo->FileName, pNameInfo->FileNameLength / sizeof(WCHAR));
+        if ((name.find(L"msys-") == std::wstring::npos
+             && name.find(L"cygwin-") == std::wstring::npos)
+            || name.find(L"-pty") == std::wstring::npos) {
+            return false;
+        }
+
+        return true;
+    }
+
+#endif
+
+    inline bool isTerminal(const std::streambuf *osbuf) noexcept
+    {
+        using std::cerr;
+        using std::clog;
+        using std::cout;
+#if defined(OS_LINUX) || defined(OS_MAC)
+        if (osbuf == cout.rdbuf()) {
+            static const bool cout_term = isatty(fileno(stdout)) != 0;
+            return cout_term;
+        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+            static const bool cerr_term = isatty(fileno(stderr)) != 0;
+            return cerr_term;
+        }
+#elif defined(OS_WIN)
+        if (osbuf == cout.rdbuf()) {
+            static const bool cout_term
+              = (_isatty(_fileno(stdout)) || isMsysPty(_fileno(stdout)));
+            return cout_term;
+        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+            static const bool cerr_term
+              = (_isatty(_fileno(stderr)) || isMsysPty(_fileno(stderr)));
+            return cerr_term;
+        }
+#endif
+        return false;
+    }
+
+    template <typename T>
+    using enableStd = typename std::enable_if<
+      std::is_same<T, rang::style>::value || std::is_same<T, rang::fg>::value
+        || std::is_same<T, rang::bg>::value || std::is_same<T, rang::fgB>::value
+        || std::is_same<T, rang::bgB>::value,
+      std::ostream &>::type;
+
+
+#ifdef OS_WIN
+
+    struct SGR {  // Select Graphic Rendition parameters for Windows console
+        BYTE fgColor;  // foreground color (0-15) lower 3 rgb bits + intense bit
+        BYTE bgColor;  // background color (0-15) lower 3 rgb bits + intense bit
+        BYTE bold;  // emulated as FOREGROUND_INTENSITY bit
+        BYTE underline;  // emulated as BACKGROUND_INTENSITY bit
+        BOOLEAN inverse;  // swap foreground/bold & background/underline
+        BOOLEAN conceal;  // set foreground/bold to background/underline
+    };
+
+    enum class AttrColor : BYTE {  // Color attributes for console screen buffer
+        black   = 0,
+        red     = 4,
+        green   = 2,
+        yellow  = 6,
+        blue    = 1,
+        magenta = 5,
+        cyan    = 3,
+        gray    = 7
+    };
+
+    inline HANDLE getConsoleHandle(const std::streambuf *osbuf) noexcept
+    {
+        if (osbuf == std::cout.rdbuf()) {
+            static const HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+            return hStdout;
+        } else if (osbuf == std::cerr.rdbuf() || osbuf == std::clog.rdbuf()) {
+            static const HANDLE hStderr = GetStdHandle(STD_ERROR_HANDLE);
+            return hStderr;
+        }
+        return INVALID_HANDLE_VALUE;
+    }
+
+    inline bool setWinTermAnsiColors(const std::streambuf *osbuf) noexcept
+    {
+        HANDLE h = getConsoleHandle(osbuf);
+        if (h == INVALID_HANDLE_VALUE) {
+            return false;
+        }
+        DWORD dwMode = 0;
+        if (!GetConsoleMode(h, &dwMode)) {
+            return false;
+        }
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        if (!SetConsoleMode(h, dwMode)) {
+            return false;
+        }
+        return true;
+    }
+
+    inline bool supportsAnsi(const std::streambuf *osbuf) noexcept
+    {
+        using std::cerr;
+        using std::clog;
+        using std::cout;
+        if (osbuf == cout.rdbuf()) {
+            static const bool cout_ansi
+              = (isMsysPty(_fileno(stdout)) || setWinTermAnsiColors(osbuf));
+            return cout_ansi;
+        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+            static const bool cerr_ansi
+              = (isMsysPty(_fileno(stderr)) || setWinTermAnsiColors(osbuf));
+            return cerr_ansi;
+        }
+        return false;
+    }
+
+    inline const SGR &defaultState() noexcept
+    {
+        static const SGR defaultSgr = []() -> SGR {
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            WORD attrib = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE),
+                                           &info)
+                || GetConsoleScreenBufferInfo(GetStdHandle(STD_ERROR_HANDLE),
+                                              &info)) {
+                attrib = info.wAttributes;
+            }
+            SGR sgr     = { 0, 0, 0, 0, FALSE, FALSE };
+            sgr.fgColor = attrib & 0x0F;
+            sgr.bgColor = (attrib & 0xF0) >> 4;
+            return sgr;
+        }();
+        return defaultSgr;
+    }
+
+    inline BYTE ansi2attr(BYTE rgb) noexcept
+    {
+        static const AttrColor rev[8]
+          = { AttrColor::black,  AttrColor::red,  AttrColor::green,
+              AttrColor::yellow, AttrColor::blue, AttrColor::magenta,
+              AttrColor::cyan,   AttrColor::gray };
+        return static_cast<BYTE>(rev[rgb]);
+    }
+
+    inline void setWinSGR(rang::bg col, SGR &state) noexcept
+    {
+        if (col != rang::bg::reset) {
+            state.bgColor = ansi2attr(static_cast<BYTE>(col) - 40);
+        } else {
+            state.bgColor = defaultState().bgColor;
+        }
+    }
+
+    inline void setWinSGR(rang::fg col, SGR &state) noexcept
+    {
+        if (col != rang::fg::reset) {
+            state.fgColor = ansi2attr(static_cast<BYTE>(col) - 30);
+        } else {
+            state.fgColor = defaultState().fgColor;
+        }
+    }
+
+    inline void setWinSGR(rang::bgB col, SGR &state) noexcept
+    {
+        state.bgColor = (BACKGROUND_INTENSITY >> 4)
+          | ansi2attr(static_cast<BYTE>(col) - 100);
+    }
+
+    inline void setWinSGR(rang::fgB col, SGR &state) noexcept
+    {
+        state.fgColor
+          = FOREGROUND_INTENSITY | ansi2attr(static_cast<BYTE>(col) - 90);
+    }
+
+    inline void setWinSGR(rang::style style, SGR &state) noexcept
+    {
+        switch (style) {
+            case rang::style::reset: state = defaultState(); break;
+            case rang::style::bold: state.bold = FOREGROUND_INTENSITY; break;
+            case rang::style::underline:
+            case rang::style::blink:
+                state.underline = BACKGROUND_INTENSITY;
+                break;
+            case rang::style::reversed: state.inverse = TRUE; break;
+            case rang::style::conceal: state.conceal = TRUE; break;
+            default: break;
+        }
+    }
+
+    inline SGR &current_state() noexcept
+    {
+        static SGR state = defaultState();
+        return state;
+    }
+
+    inline WORD SGR2Attr(const SGR &state) noexcept
+    {
+        WORD attrib = 0;
+        if (state.conceal) {
+            if (state.inverse) {
+                attrib = (state.fgColor << 4) | state.fgColor;
+                if (state.bold)
+                    attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
             } else {
-                state.bgColor = defaultState().bgColor;
+                attrib = (state.bgColor << 4) | state.bgColor;
+                if (state.underline)
+                    attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
             }
+        } else if (state.inverse) {
+            attrib = (state.fgColor << 4) | state.bgColor;
+            if (state.bold) attrib |= BACKGROUND_INTENSITY;
+            if (state.underline) attrib |= FOREGROUND_INTENSITY;
+        } else {
+            attrib = state.fgColor | (state.bgColor << 4) | state.bold
+              | state.underline;
         }
+        return attrib;
+    }
 
-        inline void setWinSGR(rang::fg col, SGR &state) noexcept
-        {
-            if (col != rang::fg::reset) {
-                state.fgColor = ansi2attr(static_cast<BYTE>(col) - 30);
-            } else {
-                state.fgColor = defaultState().fgColor;
-            }
+    template <typename T>
+    inline void setWinColorAnsi(std::ostream &os, T const value)
+    {
+        os << "\033[" << static_cast<int>(value) << "m";
+    }
+
+    template <typename T>
+    inline void setWinColorNative(std::ostream &os, T const value)
+    {
+        const HANDLE h = getConsoleHandle(os.rdbuf());
+        if (h != INVALID_HANDLE_VALUE) {
+            setWinSGR(value, current_state());
+            // Out all buffered text to console with previous settings:
+            os.flush();
+            SetConsoleTextAttribute(h, SGR2Attr(current_state()));
         }
+    }
 
-        inline void setWinSGR(rang::bgB col, SGR &state) noexcept
-        {
-            state.bgColor = (BACKGROUND_INTENSITY >> 4)
-              | ansi2attr(static_cast<BYTE>(col) - 100);
-        }
-
-        inline void setWinSGR(rang::fgB col, SGR &state) noexcept
-        {
-            state.fgColor
-              = FOREGROUND_INTENSITY | ansi2attr(static_cast<BYTE>(col) - 90);
-        }
-
-        inline void setWinSGR(rang::style style, SGR &state) noexcept
-        {
-            switch (style) {
-                case rang::style::reset: state = defaultState(); break;
-                case rang::style::bold: state.bold = FOREGROUND_INTENSITY; break;
-                case rang::style::underline:
-                case rang::style::blink:
-                    state.underline = BACKGROUND_INTENSITY;
-                    break;
-                case rang::style::reversed: state.inverse = TRUE; break;
-                case rang::style::conceal: state.conceal = TRUE; break;
-                default: break;
-            }
-        }
-
-        inline SGR &current_state() noexcept
-        {
-            static SGR state = defaultState();
-            return state;
-        }
-
-        inline WORD SGR2Attr(const SGR &state) noexcept
-        {
-            WORD attrib = 0;
-            if (state.conceal) {
-                if (state.inverse) {
-                    attrib = (state.fgColor << 4) | state.fgColor;
-                    if (state.bold)
-                        attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
-                } else {
-                    attrib = (state.bgColor << 4) | state.bgColor;
-                    if (state.underline)
-                        attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
-                }
-            } else if (state.inverse) {
-                attrib = (state.fgColor << 4) | state.bgColor;
-                if (state.bold) attrib |= BACKGROUND_INTENSITY;
-                if (state.underline) attrib |= FOREGROUND_INTENSITY;
-            } else {
-                attrib = state.fgColor | (state.bgColor << 4) | state.bold
-                  | state.underline;
-            }
-            return attrib;
-        }
-
-        template <typename T>
-        inline void setWinColorAnsi(std::ostream &os, T const value)
-        {
-            os << "\033[" << static_cast<int>(value) << "m";
-        }
-
-        template <typename T>
-        inline void setWinColorNative(std::ostream &os, T const value)
-        {
-            const HANDLE h = getConsoleHandle(os.rdbuf());
-            if (h != INVALID_HANDLE_VALUE) {
-                setWinSGR(value, current_state());
-                // Out all buffered text to console with previous settings:
-                os.flush();
-                SetConsoleTextAttribute(h, SGR2Attr(current_state()));
-            }
-        }
-
-        template <typename T>
-        inline enableStd<T> setColor(std::ostream &os, T const value)
-        {
-            if (winTermMode() == winTerm::Auto) {
-                if (supportsAnsi(os.rdbuf())) {
-                    setWinColorAnsi(os, value);
-                } else {
-                    setWinColorNative(os, value);
-                }
-            } else if (winTermMode() == winTerm::Ansi) {
+    template <typename T>
+    inline enableStd<T> setColor(std::ostream &os, T const value)
+    {
+        if (winTermMode() == winTerm::Auto) {
+            if (supportsAnsi(os.rdbuf())) {
                 setWinColorAnsi(os, value);
             } else {
                 setWinColorNative(os, value);
             }
-            return os;
+        } else if (winTermMode() == winTerm::Ansi) {
+            setWinColorAnsi(os, value);
+        } else {
+            setWinColorNative(os, value);
         }
-    #else
-        template <typename T>
-        inline enableStd<T> setColor(std::ostream &os, T const value)
-        {
-            return os << "\033[" << static_cast<int>(value) << "m";
-        }
-    #endif
-    }  // namespace rang_implementation
-
+        return os;
+    }
+#else
     template <typename T>
-    inline rang_implementation::enableStd<T> operator<<(std::ostream &os,
-                                                        const T value)
+    inline enableStd<T> setColor(std::ostream &os, T const value)
     {
-        const control option = rang_implementation::controlMode();
-        switch (option) {
-            case control::Auto:
-                return rang_implementation::supportsColor()
-                    && rang_implementation::isTerminal(os.rdbuf())
-                  ? rang_implementation::setColor(os, value)
-                  : os;
-            case control::Force: return rang_implementation::setColor(os, value);
-            default:    return os;
-        }
+        return os << "\033[" << static_cast<int>(value) << "m";
     }
+#endif
+}  // namespace rang_implementation
 
-    inline void setWinTermMode(const rang::winTerm value) noexcept
-    {
-        rang_implementation::winTermMode() = value;
-    }
-
-    inline void setControlMode(const control value) noexcept
-    {
-        rang_implementation::controlMode() = value;
-    }
-
-}  // namespace rang
-
-
-/**
-
-This is a buffer class to store all the settings the user wants to apply on the terminal.
-
-*/
-
-class RangBuffer
+template <typename T>
+inline rang_implementation::enableStd<T> operator<<(std::ostream &os,
+                                                    const T value)
 {
-    private:
+    const control option = rang_implementation::controlMode();
+    switch (option) {
+        case control::Auto:
+            return rang_implementation::supportsColor()
+                && rang_implementation::isTerminal(os.rdbuf())
+              ? rang_implementation::setColor(os, value)
+              : os;
+        case control::Force: return rang_implementation::setColor(os, value);
+        default: return os;
+    }
+}
 
-    //The settings user can to apply
-    rang::style style;
+inline void setWinTermMode(const rang::winTerm value) noexcept
+{
+    rang_implementation::winTermMode() = value;
+}
 
-    rang::bg bgColor;
-    rang::bgB bgBColor;
+inline void setControlMode(const control value) noexcept
+{
+    rang_implementation::controlMode() = value;
+}
 
-    rang::fg fgColor;
-    rang::fgB fgBColor;
+class buffer
+{
+private:
 
-    //to check the user has applied which settings
-    std::bitset<5> elementSet;
+    std::string m_finalColor = "";
+public:
 
-    public:
-
-    //initliaze elementSet. It contains 0 in each bit
-    RangBuffer() : elementSet()
-    {    }
-
-    /**ask the compiler to make the copy and move contructor and copy and move operator because
+    /**
+    ask the compiler to make the default contructors because
         1) The compiler is much better
         2) It will add a utility if the user wants to play around
     */
-    RangBuffer(const RangBuffer& rg) = default;
-    RangBuffer(RangBuffer&& rg) = default;
 
-    RangBuffer& operator=(const RangBuffer& rg) = default;
-    RangBuffer& operator=(RangBuffer&& rg) = default;
+    buffer() = default;
 
-    // setter helper functions
-    void setStyle(const rang::style s)
+    buffer(const buffer& b) = default;
+    buffer(buffer&& b) = default;
+
+    buffer& operator=(const buffer& b) = default;
+    buffer& operator=(buffer&& b) = default;
+
+    void style(rang::style s)
     {
-        style = s;
-        elementSet[0] = true;
+        std::stringstream ss;
+        ss << "\033[" << static_cast<int>(s) << "m";
+        m_finalColor += ss.str();
     }
 
-    void setBgColor(const rang::bg bg)
+    void bg(rang::bg b)
     {
-        bgColor = bg;
-        elementSet[1] = true;
+        std::stringstream ss;
+        ss << "\033[" << static_cast<int>(b) << "m";
+        m_finalColor += ss.str();
     }
 
-    void setBgBColor(const rang::bgB bgB)
+    void bgB(rang::bgB b)
     {
-        bgBColor = bgB;
-        elementSet[2] = true;
+        std::stringstream ss;
+        ss << "\033[" << static_cast<int>(b) << "m";
+        m_finalColor += ss.str();
     }
 
-    void setFgColor(rang::fg fg)
+    void fg(rang::fg f)
     {
-        fgColor = fg;
-        elementSet[3] = true;
+        std::stringstream ss;
+        ss << "\033[" << static_cast<int>(f) << "m";
+        m_finalColor += ss.str();
     }
 
-    void setFgBColor(rang::fgB fgB)
+    void fgB(rang::fgB f)
     {
-        fgBColor = fgB;
-        elementSet[4] = true;
+        std::stringstream ss;
+        ss << "\033[" << static_cast<int>(f) << "m";
+        m_finalColor += ss.str();
     }
 
-    //reset the object as if it was new
-    std::ostream& reset(std::ostream& os)
+    friend std::ostream& operator<<(std::ostream& os, const buffer& b)
     {
-        for(size_t i = 0;i < this->elementSet.size();++i)
-            this->elementSet.set(i, false);
+        //an extra precaution that someone does not call operator << just after clearing the buffer.
+        //Though, it does not cause any harm, I don't want to take a chance
 
-        os << rang::style::reset;
+        if (b.m_finalColor != "")
+            os << b.m_finalColor;
 
         return os;
     }
 
     /**
-        an interesting function. This resets the terminal. but keeps the settings of this object as is. It is meant to be used like this:
+        This resets the terminal. but keeps the settings of this object as is. It is meant to be used like this:
 
         RangBuffer rg;
 
@@ -605,37 +581,32 @@ class RangBuffer
         //displayed as the first hello world
         cout << rg << "This is my first contribution";
     */
-    std::ostream& ignoreMySettings(std::ostream& os)
+    std::ostream& ingore(std::ostream& os)
     {
-        os << "\033[0m";
+        os << rang::style::reset;
         return os;
     }
 
-    friend std::ostream& operator<<(std::ostream& os, const RangBuffer& r)
+    //resets the buffer
+    void reset()
     {
-        if(r.elementSet.test(0))
-            os << r.style;
-
-        if(r.elementSet.test(1))
-            os << r.bgColor;
-
-        if(r.elementSet.test(2))
-            os << r.bgBColor;
-
-        if(r.elementSet.test(3))
-            os << r.fgColor;
-
-        if(r.elementSet.test(4))
-            os << r.fgBColor;
-
-        return os;
+        m_finalColor = "";
     }
 
-    ~RangBuffer() = default;
+    //resets the buffer as well as ostream
+    std::ostream& reset(std::ostream& os)
+    {
+        m_finalColor = "";
+        os << rang::style::reset;
+        return os;
+    }
 };
+
+}  // namespace rang
 
 #undef OS_LINUX
 #undef OS_WIN
 #undef OS_MAC
 
 #endif /* ifndef RANG_DOT_HPP */
+

--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -578,8 +578,8 @@ class RangBuffer
     //reset the object as if it was new
     std::ostream& reset(std::ostream& os)
     {
-        for(size_t i = 0;i < this.elementSet.size();++i)
-            this.elementSet.set(i, false);
+        for(size_t i = 0;i < this->elementSet.size();++i)
+            this->elementSet.set(i, false);
 
         os << rang::style::reset;
 
@@ -605,7 +605,6 @@ class RangBuffer
         //displayed as the first hello world
         cout << rg << "This is my first contribution";
     */
-
     std::ostream& ignoreMySettings(std::ostream& os)
     {
         os << "\033[0m";
@@ -640,4 +639,3 @@ class RangBuffer
 #undef OS_MAC
 
 #endif /* ifndef RANG_DOT_HPP */
-

--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -499,7 +499,7 @@ class buffer
 {
 private:
 
-    std::string m_finalColor = "";
+    std::stringstream m_finalColor;
 public:
 
     /**
@@ -518,37 +518,28 @@ public:
 
     void style(const rang::style s)
     {
-        std::stringstream ss;
-        ss << "\033[" << static_cast<int>(s) << "m";
-        m_finalColor += ss.str();
+        m_finalColor << "\033[" << static_cast<int>(s) << "m";
+
     }
 
     void bg(const rang::bg b)
     {
-        std::stringstream ss;
-        ss << "\033[" << static_cast<int>(b) << "m";
-        m_finalColor += ss.str();
+        m_finalColor << "\033[" << static_cast<int>(b) << "m";
     }
 
     void bgB(const rang::bgB b)
     {
-        std::stringstream ss;
-        ss << "\033[" << static_cast<int>(b) << "m";
-        m_finalColor += ss.str();
+        m_finalColor << "\033[" << static_cast<int>(b) << "m";
     }
 
     void fg(const rang::fg f)
     {
-        std::stringstream ss;
-        ss << "\033[" << static_cast<int>(f) << "m";
-        m_finalColor += ss.str();
+        m_finalColor << "\033[" << static_cast<int>(f) << "m";
     }
 
     void fgB(const rang::fgB f)
     {
-        std::stringstream ss;
-        ss << "\033[" << static_cast<int>(f) << "m";
-        m_finalColor += ss.str();
+        m_finalColor << "\033[" << static_cast<int>(f) << "m";
     }
 
     friend std::ostream& operator<<(std::ostream& os, const buffer& b)
@@ -556,7 +547,7 @@ public:
         //an extra precaution that someone does not call operator << just after clearing the buffer.
         //Though, it does not cause any harm, I don't want to take a chance
 
-        if (b.m_finalColor != "")
+        if (!b.m_finalColor.str().empty())
             os << b.m_finalColor;
 
         return os;
@@ -581,6 +572,7 @@ public:
         //displayed as the first hello world
         cout << rg << "This is my first contribution";
     */
+
     std::ostream& ingore(std::ostream& os)
     {
         os << rang::style::reset;
@@ -590,13 +582,13 @@ public:
     //resets the buffer
     void reset()
     {
-        m_finalColor = "";
+        m_finalColor.str(std::string());
     }
 
     //resets the buffer as well as ostream
     std::ostream& reset(std::ostream& os)
     {
-        m_finalColor = "";
+        m_finalColor.str(std::string());
         os << rang::style::reset;
         return os;
     }
@@ -609,3 +601,4 @@ public:
 #undef OS_MAC
 
 #endif /* ifndef RANG_DOT_HPP */
+

--- a/include/rang.hpp
+++ b/include/rang.hpp
@@ -544,6 +544,7 @@ class RangBuffer
     RangBuffer& operator=(const RangBuffer& rg) = default;
     RangBuffer& operator=(RangBuffer&& rg) = default;
 
+    // setter helper functions
     void setStyle(const rang::style s)
     {
         style = s;
@@ -574,10 +575,41 @@ class RangBuffer
         elementSet[4] = true;
     }
 
-    void clear()
+    //reset the object as if it was new
+    std::ostream& reset(std::ostream& os)
     {
-        for(size_t i = 0;i < elementSet.size();++i)
-            elementSet[i] = false;
+        for(size_t i = 0;i < this.elementSet.size();++i)
+            this.elementSet.set(i, false);
+
+        os << rang::style::reset;
+
+        return os;
+    }
+
+    /**
+        an interesting function. This resets the terminal. but keeps the settings of this object as is. It is meant to be used like this:
+
+        RangBuffer rg;
+
+        rg.setBgColor(rang::bg::cyan);
+        rg.setFgBColor(rang::fgB::yellow);
+
+        //displayed with cyan background and bright yellow foreground
+        cout << rg << "hello world\n" << endl;
+
+        rg.ignoreMySettings(cout);
+
+        //displayed with the default foregrouond and background
+        cout << "hello world\n";
+
+        //displayed as the first hello world
+        cout << rg << "This is my first contribution";
+    */
+
+    std::ostream& ignoreMySettings(std::ostream& os)
+    {
+        os << "\033[0m";
+        return os;
     }
 
     friend std::ostream& operator<<(std::ostream& os, const RangBuffer& r)
@@ -608,3 +640,4 @@ class RangBuffer
 #undef OS_MAC
 
 #endif /* ifndef RANG_DOT_HPP */
+


### PR DESCRIPTION
I created a RangBuffer class to store the display settings in an object. You might want to make a class 'buffer' inside rang namespace. It has setter functions to set the properties. This is how it works:

    RangBuffer rg;

    rg.setBgColor(rang::bg::cyan);
    rg.setFgBColor(rang::fgB::yellow);
    
    cout << rg << "hello world\n" << endl;
    rg.ignoreMySettings(cout);
    
    RangBuffer rg2;
    rg2.setBgBColor(rang::bgB::blue);
    cout << rg2 << "hello world\n";
    cout << rg << "This is my first contribution";

There is a unique function RangBuffer::ignoreMysettings(std::ostream& os). It resets the ostream. So for example in the above code, the second line is displayed with a bright blue background and white foreground. Commenting that line will display the second line with a bright blue background and yellow colour (set by rg1).

Now you might be wandering what's the difference between ignoreMySettings and reset()?
- Reset resets the all the bitset (elementSet) to 0 in addition to resetting the terminal. So, after calling the clear function, it is as good as a new object.
- IgnoreMySettings resets the terminal but does not reset the bitset. It means the next time the object is used to display using ostream.

Plus, the design choice is such that say you have a common setting that the text you display is red, but at some point, you want red and the text to be bold, you can do this:
   ```
 RangBuffer rg;
 rg.setFgBColor(rang::fgB::red);

 cout << rang::style::bold << rg << "Hello world";
 rg.reset(cout);
```
And it does all this without breaking code.

I compiled my example on g++(version 8.2.1) and clang++(version 7.0) both on my Fedora 29. And it works as expected