### PR TITLE
Update CMake min version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.20)
 
 project(rang 
     VERSION 3.2.0


### PR DESCRIPTION
Updated CMake minimum version to 3.20, because version 3.1 is now deprecated.