### PR TITLE
Update cmake_minimum_required() in CMakeLists.txt to support CMake >= 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(rang 
     VERSION 3.2.0


### PR DESCRIPTION
Previous issues were opened on the subject of CMake minimum version compatibility but never tackled ([latest issue from Feb 20th 2025](https://github.com/agauniyal/rang/issues/139#issue-2865837277)).

Since the release of CMake 4.0, versions older than 3.5 aren't compatible anymore, causing project configuration errors ([CMake 4.0 changelog](https://cmake.org/cmake/help/latest/release/4.0.html)).